### PR TITLE
item record changes for PFRPG2 support

### DIFF
--- a/campaign/record_item_pf2.xml
+++ b/campaign/record_item_pf2.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!-- Please see the LICENSE.md file included with this distribution for attribution and copyright information. -->
+
+<root>
+	<!-- this is the item sheet -->
+	<windowclass name="item_main" merge="join">
+		<sheetdata>
+			<label_column name="container_bulk_label" insertbefore="bulk_label" >
+				<static textres="item_label_container_bulk" />
+			</label_column>
+			<number_columnh name="capacityweight" insertbefore="bulk_label">
+				<tooltip textres="item_tooltip_capacityweight_bulk" />
+				<script>
+					function update(bReadOnly, bForceHide)
+						local bLocalShow;
+						if bForceHide then
+							bLocalShow = false;
+						else
+							--[[bmos fixing visibility of weight fields]]
+							local nohide = ExtraplanarContainers.isAnyContainer(DB.getValue(window.getDatabaseNode(), 'name'));
+							--[[end bmos fixing visibility of weight fields]]
+							bLocalShow = true;
+							if bReadOnly and not nohide and getValue() == 0 then
+								bLocalShow = false;
+							end
+						end
+
+						setReadOnly(bReadOnly);
+						setVisible(bLocalShow);
+						
+						local sLabel = getName() .. "_label";
+						if window[sLabel] then
+							window[sLabel].setVisible(bLocalShow);
+						end
+						
+						if self.onUpdate then
+							self.onUpdate(bLocalShow);
+						end
+						
+						return bLocalShow;
+					end
+					function onValueChanged()
+						window.extraplanarcontents.onValueChanged()
+					end
+				</script>
+			</number_columnh>
+			<basicnumber name="extraplanarcontents" insertbefore="bulk_label">
+				<anchored to="capacityweight" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_extraplanarcontents_bulk" />
+				<readonly />
+				<script>
+					function onInit()
+						local bVisible = ExtraplanarContainers.isAnyContainer(DB.getValue(window.getDatabaseNode(), 'name'))
+						window.container_bulk_label.setVisible(bVisible)
+						window.capacityweight.setVisible(bVisible or window.capacityweight.getValue() ~= 0)
+						window.extraplanarcontents.setVisible(bVisible or window.extraplanarcontents.getValue() ~= 0)
+						onValueChanged()
+					end
+					function onValueChanged()
+						if window.capacityweight.getValue() ~= 0 then
+							if getValue() &lt; window.capacityweight.getValue() then
+								setColor(ColorManager.COLOR_FULL)
+							elseif getValue() == window.capacityweight.getValue() then
+								setColor(ColorManager.COLOR_HEALTH_HVY_WOUNDS)
+							elseif getValue() &gt; window.capacityweight.getValue() then
+								setColor(ColorManager.COLOR_HEALTH_CRIT_WOUNDS)
+							end
+						end
+					end
+				</script>
+			</basicnumber>
+			<basicnumber name="contentsvolume" insertbefore="bulk_label" >
+				<anchored to="extraplanarcontents" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_contentsvolume" />
+				<readonly />
+				<script>
+					function onInit()
+						local bVisible = OptionsManager.isOption('ITEM_VOLUME', 'on')
+
+						window.external_dimensions_label.setVisible(bVisible)
+						window.length.setVisible(bVisible)
+						window.width.setVisible(bVisible)
+						window.depth.setVisible(bVisible)
+						window.volume.setVisible(bVisible)
+
+						bVisible = bVisible and ExtraplanarContainers.isAnyContainer(DB.getValue(window.getDatabaseNode(), 'name'))
+
+						window.contentsvolume.setVisible(bVisible)
+						window.internal_dimensions_label.setVisible(bVisible)
+						window.internal_length.setVisible(bVisible)
+						window.internal_width.setVisible(bVisible)
+						window.internal_depth.setVisible(bVisible)
+						window.internal_volume.setVisible(bVisible)
+
+						onValueChanged()
+					end
+					function onValueChanged()
+						if window.internal_volume.getValue() ~= 0 then
+							if getValue() &lt; window.internal_volume.getValue() then
+								setColor(ColorManager.COLOR_FULL)
+							elseif getValue() == window.internal_volume.getValue() then
+								setColor(ColorManager.COLOR_HEALTH_HVY_WOUNDS)
+							elseif getValue() &gt; window.internal_volume.getValue() then
+								setColor(ColorManager.COLOR_HEALTH_CRIT_WOUNDS)
+							end
+						end
+					end
+				</script>
+			</basicnumber>
+			
+			<label_column name="external_dimensions_label" insertbefore="divider3" >
+				<static textres="item_label_external_dimensions" />
+			</label_column>
+			<number_columnh name="length" insertbefore="divider3" >
+				<delaykeyupdate />
+				<tooltip textres="item_tooltip_length" />
+				<script>
+					function onValueChanged()
+						window.volume.getVolume()
+					end
+				</script>
+			</number_columnh>
+			<basicnumber name="width" insertbefore="divider3" >
+				<anchored to="length" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_width" />
+				<delaykeyupdate />
+				<script>
+					function onValueChanged()
+						window.volume.getVolume()
+					end
+				</script>
+			</basicnumber>
+			<basicnumber name="depth" insertbefore="divider3" >
+				<anchored to="width" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_depth" />
+				<delaykeyupdate />
+				<script>
+					function onValueChanged()
+						window.volume.getVolume()
+					end
+				</script>
+			</basicnumber>
+			<basicnumber name="volume" insertbefore="divider3" >
+				<anchored to="depth" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_exterior_volume" />
+				<readonly />
+				<script>
+					function onInit()
+						getVolume()
+					end
+					function getVolume()
+						setValue(window.length.getValue() * window.width.getValue() * window.depth.getValue())
+						window.contentsvolume.onValueChanged()
+					end
+					function onValueChanged()
+						window.contentsvolume.onValueChanged()
+					end
+				</script>
+			</basicnumber>
+			
+			<label_column name="internal_dimensions_label" insertbefore="divider3" >
+				<static textres="item_label_internal_dimensions" />
+			</label_column>
+			<number_columnh name="internal_length" insertbefore="divider3" >
+				<tooltip textres="item_tooltip_length" />
+				<delaykeyupdate />
+				<script>
+					function onValueChanged()
+						window.internal_volume.getVolume()
+					end
+				</script>
+			</number_columnh>
+			<basicnumber name="internal_width" insertbefore="divider3" >
+				<anchored to="internal_length" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_width" />
+				<delaykeyupdate />
+				<script>
+					function onValueChanged()
+						window.internal_volume.getVolume()
+					end
+				</script>
+			</basicnumber>
+			<basicnumber name="internal_depth" insertbefore="divider3" >
+				<anchored to="internal_width" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_depth" />
+				<delaykeyupdate />
+				<script>
+					function onValueChanged()
+						window.internal_volume.getVolume()
+					end
+				</script>
+			</basicnumber>
+			<basicnumber name="internal_volume" insertbefore="divider3" >
+				<anchored to="internal_depth" position="righthigh" offset="10,0" width="35" height="20" />
+				<tooltip textres="item_tooltip_interior_volume" />
+				<readonly />
+				<script>
+					function onInit()
+						getVolume()
+					end
+					function getVolume()
+						setValue(window.internal_length.getValue() * window.internal_width.getValue() * window.internal_depth.getValue())
+					end
+				</script>
+			</basicnumber>
+		</sheetdata>
+	</windowclass>
+</root>

--- a/extension.xml
+++ b/extension.xml
@@ -16,6 +16,7 @@
 		<!-- Records -->
 		<includefile ruleset="CoreRPG" source="campaign/record_item.xml" />
 		<includefile ruleset="PFRPG" source="campaign/record_item.xml" />
+		<includefile ruleset="PFRPG2" source="campaign/record_item_pf2.xml" />
 		<includefile ruleset="2E" source="campaign/record_item.xml" />
 		<includefile ruleset="3.5E" source="campaign/record_item.xml" />
 		<includefile ruleset="4E" source="campaign/record_item_4e.xml" />

--- a/strings/strings_extraplanarcontainers.xml
+++ b/strings/strings_extraplanarcontainers.xml
@@ -18,6 +18,10 @@
 	<string name="item_tooltip_depth">Depth</string>
 	<string name="item_tooltip_exterior_volume">Total Exterior Volume</string>
 	<string name="item_tooltip_interior_volume">Total Interior Volume</string>
+	<!-- PFRPG2 strings-->
+	<string name="item_label_container_bulk">Container Bulk</string>
+	<string name="item_tooltip_capacityweight_bulk">Maximum Bulk Capacity</string> <!-- Total bulk the bag of holding can hold (as PF2 bulk) -->
+	<string name="item_tooltip_extraplanarcontents_bulk">Total Bulk of Contents</string> <!-- The weight of everything in the bag of holding (as PF2 bulk) -->
 	<!-- Chat Messages -->
 	<string name="item_self_destruct">"%s" is overfull (%s). Self destructing in 10.. 9.. 8.. 6.. just kidding!</string>
 	<string name="item_overfull">"%s" is overfull (%s).</string>


### PR DESCRIPTION
On PFRPG2 there is no weight. That row hidden field on item record on PF2 ruleset. Instead "Bulk" is used. In effect you can not see or edit fields like "Maximum Weight Capacity" or "Weight of Contents" in PF2 item details 

Aside from item details screen all other calculations seems to be working ok. Fixes here are just adding a new row for these container properties just above the "Bulk" row.

Before fix:
![image](https://user-images.githubusercontent.com/1773628/156925112-719be165-8225-4439-8dcb-7987645899be.png)


After fix
![image](https://user-images.githubusercontent.com/1773628/156925059-38a172ce-9ca9-4946-8896-11de0df9c3c7.png)

